### PR TITLE
Add backend rule tests and CI workflow

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,26 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt pytest
+
+      - name: Run backend rule tests
+        run: pytest -q backend/tests

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/tests/test_rules_bacs.py
+++ b/backend/tests/test_rules_bacs.py
@@ -1,0 +1,41 @@
+from copy import deepcopy
+
+import pytest
+
+from backend.agent_core.checks.kg480_bacs import evaluate
+
+
+BASE_CONTEXT = {
+    "systeme": [
+        {"gewerk": "kg420", "klasse": "A"},
+        {"gewerk": "kg440", "klasse": "B"},
+    ],
+    "messstellen": [
+        {"kategorie": "hvac", "flaeche": 200.0, "anzahl": 4},
+        {"kategorie": "lighting", "flaeche": 200.0, "anzahl": 3},
+    ],
+    "trendaufzeichnung_tage": 45.0,
+    "alarmreaktionszeit": 200.0,
+}
+
+
+def build_context(**overrides):
+    context = deepcopy(BASE_CONTEXT)
+    for key, value in overrides.items():
+        context[key] = value
+    return context
+
+
+@pytest.mark.parametrize(
+    "trend_days, expected_ids",
+    [
+        (45.0, []),
+        (14.0, ["kg480_trendaufzeichnung"]),
+    ],
+)
+def test_trend_storage_requirement(trend_days, expected_ids):
+    context = build_context(trendaufzeichnung_tage=trend_days)
+
+    findings = evaluate(context)
+
+    assert {finding.id for finding in findings} == set(expected_ids)

--- a/backend/tests/test_rules_electrical.py
+++ b/backend/tests/test_rules_electrical.py
@@ -1,0 +1,65 @@
+from copy import deepcopy
+
+import pytest
+
+from backend.agent_core.checks.kg440_electrical import evaluate
+
+
+BASE_CONTEXT = {
+    "projekt_typ": "buerogebaeude",
+    "stromkreise": [
+        {
+            "name": "HV1",
+            "voltage_drop_percent": 2.5,
+            "diversity_factor": 0.8,
+            "reserve_percent": 15.0,
+        }
+    ],
+    "beleuchtung": [
+        {
+            "id": "B1",
+            "flaeche": 100.0,
+            "leistung": 1000.0,
+            "nutzung": "buerogebaeude",
+        }
+    ],
+    "verbraucher": [
+        {"bereich": "rechenzentrum", "usv_erforderlich": True},
+        {"bereich": "operationssaal", "usv_erforderlich": True},
+    ],
+    "notbeleuchtung": True,
+}
+
+
+def build_context(**overrides):
+    context = deepcopy(BASE_CONTEXT)
+    for key, value in overrides.items():
+        context[key] = value
+    return context
+
+
+def build_circuit(**overrides):
+    circuit = deepcopy(BASE_CONTEXT["stromkreise"][0])
+    circuit.update(overrides)
+    return circuit
+
+
+@pytest.mark.parametrize(
+    "circuit_overrides, expected_ids",
+    [
+        ({}, []),
+        (
+            {
+                "voltage_drop_percent": 3.5,
+            },
+            ["kg440_HV1_spannung"],
+        ),
+    ],
+)
+def test_voltage_drop_rule(circuit_overrides, expected_ids):
+    circuits = [build_circuit(**circuit_overrides)]
+    context = build_context(stromkreise=circuits)
+
+    findings = evaluate(context)
+
+    assert {finding.id for finding in findings} == set(expected_ids)

--- a/backend/tests/test_rules_fire_suppression.py
+++ b/backend/tests/test_rules_fire_suppression.py
@@ -1,0 +1,54 @@
+from copy import deepcopy
+
+import pytest
+
+from backend.agent_core.checks.kg474_fire_suppression import evaluate
+
+
+BASE_CONTEXT = {
+    "sprinkler": [
+        {
+            "name": "Zone A",
+            "gefährdungsklasse": "hoch",
+            "berechnete_dichte": 5.5,
+            "loescheinwirkzeit": 40.0,
+            "pumpenredundanz": True,
+        }
+    ],
+    "hydranten": [],
+    "wasserversorgung": {"dauer": 40.0},
+}
+
+
+def build_context(**overrides):
+    context = deepcopy(BASE_CONTEXT)
+    for key, value in overrides.items():
+        context[key] = value
+    return context
+
+
+def build_zone(**overrides):
+    zone = deepcopy(BASE_CONTEXT["sprinkler"][0])
+    zone.update(overrides)
+    return zone
+
+
+@pytest.mark.parametrize(
+    "zone_overrides, expected_ids",
+    [
+        ({}, []),
+        (
+            {
+                "berechnete_dichte": 4.0,
+            },
+            ["kg474_Zone A_dichte"],
+        ),
+    ],
+)
+def test_sprinkler_density(zone_overrides, expected_ids):
+    sprinkler = [build_zone(**zone_overrides)]
+    context = build_context(sprinkler=sprinkler)
+
+    findings = evaluate(context)
+
+    assert {finding.id for finding in findings} == set(expected_ids)

--- a/backend/tests/test_rules_heating.py
+++ b/backend/tests/test_rules_heating.py
@@ -1,0 +1,62 @@
+from copy import deepcopy
+
+import pytest
+
+from backend.agent_core.checks.kg420_heating import evaluate
+
+
+BASE_CONTEXT = {
+    "projekt_typ": "buerogebaeude",
+    "heating_load": {
+        "rooms": [
+            {
+                "name": "Raum 1",
+                "heizlast": 30.0,
+                "spezifische_heizlast": 50.0,
+            }
+        ],
+        "total": 50.0,
+    },
+    "system": {
+        "supply_temperature": 60.0,
+        "return_temperature": 45.0,
+        "pressure": 2.0,
+        "hydraulic_balancing": True,
+        "components": [
+            "wärmeerzeuger",
+            "umwälzpumpe",
+            "ausdehnungsgefäß",
+            "sicherheitsventil",
+            "manometer",
+        ],
+    },
+    "generator": {
+        "leistung": 60.0,
+        "typ": "gaskessel",
+        "wirkungsgrad": 0.95,
+    },
+}
+
+
+def build_context(**overrides):
+    context = deepcopy(BASE_CONTEXT)
+    for key, value in overrides.items():
+        context[key] = value
+    return context
+
+
+@pytest.mark.parametrize(
+    "generator_power, expected_ids",
+    [
+        (60.0, []),
+        (50.0, ["kg420_erzeuger_001"]),
+    ],
+)
+def test_generator_margin(generator_power, expected_ids):
+    generator = deepcopy(BASE_CONTEXT["generator"])
+    generator["leistung"] = generator_power
+    context = build_context(generator=generator)
+
+    findings = evaluate(context)
+
+    assert {finding.id for finding in findings} == set(expected_ids)

--- a/backend/tests/test_rules_ventilation.py
+++ b/backend/tests/test_rules_ventilation.py
@@ -1,0 +1,66 @@
+from copy import deepcopy
+
+import pytest
+
+from backend.agent_core.checks.kg430_ventilation import evaluate
+
+
+BASE_CONTEXT = {
+    "projekt_typ": "buerogebaeude",
+    "rooms": [
+        {
+            "name": "Konferenz",
+            "zuluft": 360.0,
+            "abluft": 360.0,
+            "persons": 10,
+            "air_change": 3.0,
+            "co2": 800.0,
+        }
+    ],
+    "anlagen": [
+        {
+            "id": "AHU1",
+            "volumenstrom": 1400.0,
+            "waermerueckgewinnung": True,
+            "wrg_wirkungsgrad": 0.8,
+            "filterklassen": ["F7"],
+        }
+    ],
+}
+
+
+def build_context(**overrides):
+    context = deepcopy(BASE_CONTEXT)
+    for key, value in overrides.items():
+        context[key] = value
+    return context
+
+
+def build_room(**overrides):
+    room = deepcopy(BASE_CONTEXT["rooms"][0])
+    room.update(overrides)
+    return room
+
+
+@pytest.mark.parametrize(
+    "room_overrides, expected_ids",
+    [
+        ({}, []),
+        (
+            {
+                "zuluft": 100.0,
+                "abluft": 100.0,
+                "persons": 10,
+                "co2": 800.0,
+            },
+            ["kg430_Konferenz_luftmenge"],
+        ),
+    ],
+)
+def test_outdoor_air_per_person(room_overrides, expected_ids):
+    rooms = [build_room(**room_overrides)]
+    context = build_context(rooms=rooms)
+
+    findings = evaluate(context)
+
+    assert {finding.id for finding in findings} == set(expected_ids)


### PR DESCRIPTION
## Summary
- add pytest coverage for heating, ventilation, electrical, fire suppression, and BACS rule evaluators
- ensure backend package can be imported in tests via a shared conftest helper
- configure a GitHub Actions workflow to run the new backend rule tests

## Testing
- pytest -q backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68dee21c76ac83248c121259e13f2df5