### PR TITLE
fix: handle missing sanitary hot water temperatures

### DIFF
--- a/backend/agent_core/checks/kg410_sanitary.py
+++ b/backend/agent_core/checks/kg410_sanitary.py
@@ -46,7 +46,7 @@ def evaluate(context: Mapping[str, Any]) -> List[Finding]:
         hot_temp = system.get("hot_water_temp")
         findings.extend(
             guard(
-                hot_temp is not None and float(hot_temp) >= params["hot_water_temp_min"],
+                hot_temp is None or float(hot_temp) >= params["hot_water_temp_min"],
                 lambda: Finding(
                     id=f"kg410_{label}_temp",
                     kategorie="technisch",
@@ -60,6 +60,26 @@ def evaluate(context: Mapping[str, Any]) -> List[Finding]:
                     norm_referenz="TrinkwV, DVGW W 551",
                     empfehlung="Warmwasserbereitung auf mindestens 55 °C einstellen und dokumentieren.",
                     konfidenz_score=0.85,
+                    dokument_id=dokument_id,
+                ),
+            )
+        )
+
+        findings.extend(
+            guard(
+                hot_temp is not None,
+                lambda: Finding(
+                    id=f"kg410_{label}_temp_missing",
+                    kategorie="hinweis",
+                    prioritaet="niedrig",
+                    titel="Keine Warmwassertemperatur dokumentiert",
+                    beschreibung=(
+                        f"Für das System {label} liegt keine dokumentierte Trinkwarmwassertemperatur vor."
+                        " Bitte Messwert nachreichen oder Monitoring ergänzen."
+                    ),
+                    gewerk=GEWERK,
+                    empfehlung="Temperaturaufzeichnungen ergänzen und Prüfprotokolle aktualisieren.",
+                    konfidenz_score=0.4,
                     dokument_id=dokument_id,
                 ),
             )

--- a/backend/tests/test_kg410_sanitary.py
+++ b/backend/tests/test_kg410_sanitary.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from backend.agent_core.checks.kg410_sanitary import Finding, evaluate
+
+
+def _finding_ids(findings: List[Finding]) -> set[str]:
+    return {finding.id for finding in findings}
+
+
+def test_missing_hot_water_temperature_does_not_raise_temp_finding() -> None:
+    context: Dict[str, object] = {
+        "systems": [
+            {
+                "id": "sys1",
+                "hot_water_temp": None,
+            }
+        ],
+        "fixtures": [],
+    }
+
+    findings = evaluate(context)
+
+    ids = _finding_ids(findings)
+    assert "kg410_sys1_temp" not in ids
+    assert "kg410_sys1_temp_missing" in ids
+
+
+def test_low_hot_water_temperature_triggers_temp_finding() -> None:
+    context: Dict[str, object] = {
+        "systems": [
+            {
+                "id": "sys1",
+                "hot_water_temp": 45.0,
+            }
+        ],
+        "fixtures": [],
+    }
+
+    findings = evaluate(context)
+
+    ids = _finding_ids(findings)
+    assert "kg410_sys1_temp" in ids
+    assert "kg410_sys1_temp_missing" not in ids


### PR DESCRIPTION
## Summary
- allow sanitary hot water temperature checks to treat missing measurements as no violation and surface a low priority hint instead
- add unit coverage for missing and insufficient hot water temperature scenarios

## Testing
- pytest -q backend/tests/test_kg410_sanitary.py

------
https://chatgpt.com/codex/tasks/task_e_68e1121982a083248c1110133df3421d