### PR TITLE
Fix BACS class comparison logic and tests

### DIFF
--- a/backend/agent_core/checks/kg480_bacs.py
+++ b/backend/agent_core/checks/kg480_bacs.py
@@ -35,7 +35,7 @@ def evaluate(context: Mapping[str, Any]) -> List[Finding]:
         gewerk_ref = str(system.get("gewerk") or "").lower()
         bacs_class = str(system.get("klasse") or "D")
         requirement = required_classes.get(gewerk_ref)
-        if requirement and _class_rank(bacs_class) > _class_rank(requirement):
+        if requirement and _class_rank(bacs_class) < _class_rank(requirement):
             findings.append(
                 Finding(
                     id=f"kg480_{gewerk_ref}_klasse",

--- a/backend/tests/test_kg480_bacs.py
+++ b/backend/tests/test_kg480_bacs.py
@@ -29,18 +29,18 @@ def finding_ids(findings: Iterable[object]) -> set[str]:
     return {finding.id for finding in findings}  # type: ignore[attr-defined]
 
 
-def test_bacs_class_requirement_negative():
+def test_bacs_class_requirement_worse_triggers_finding():
     context = base_context()
-    context["systeme"].append({"gewerk": "kg440", "klasse": "A"})  # type: ignore[index]
+    context["systeme"].append({"gewerk": "kg440", "klasse": "C"})  # type: ignore[index]
 
     findings = evaluate(context)
 
     assert "kg480_kg440_klasse" in finding_ids(findings)
 
 
-def test_bacs_class_requirement_positive():
+def test_bacs_class_requirement_better_no_finding():
     context = base_context()
-    context["systeme"].append({"gewerk": "kg440", "klasse": "B"})  # type: ignore[index]
+    context["systeme"].append({"gewerk": "kg440", "klasse": "A"})  # type: ignore[index]
 
     findings = evaluate(context)
 


### PR DESCRIPTION
## Summary
- adjust the BACS class comparison so only lower-ranked classes trigger findings
- extend unit coverage for better and worse class scenarios around the BACS requirement

## Testing
- pytest -q backend/tests/test_kg480_bacs.py

------
https://chatgpt.com/codex/tasks/task_e_68e113c102608324a8f8ac292574ff2b