### PR TITLE
feat: add configurable LLM client for norm agent

### DIFF
--- a/backend/agent_core/norm_agent.py
+++ b/backend/agent_core/norm_agent.py
@@ -1,12 +1,220 @@
 
-def run_norm_check(input_text: str) -> str:
-    # Platzhalter für echte MetaGPT-Rollen
-    if "Tiefgarage" in input_text and "6/h" in input_text:
-        return (
-            "Normprüfung abgeschlossen:\n"
-            "- Normbezug: VDI 2053 (Lüftung von Garagen)\n"
-            "- Geforderter Luftwechsel: >5/h\n"
-            "- Geplanter Luftwechsel: 6/h => Konform\n"
-            "Empfehlung: CO-Sensor prüfen und Wartung dokumentieren."
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from textwrap import dedent
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class LLMClientError(RuntimeError):
+    """Base exception for LLM client errors."""
+
+
+class LLMConfigurationError(LLMClientError):
+    """Raised when the LLM client is not correctly configured."""
+
+
+class LLMTimeoutError(LLMClientError):
+    """Raised when the LLM call times out."""
+
+
+class LLMRateLimitError(LLMClientError):
+    """Raised when the LLM service rate limits the request."""
+
+
+@dataclass
+class NormCheckResult:
+    norm_reference: str
+    assessment: str
+    recommendation: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class LLMClient:
+    """Configurable LLM client wrapper."""
+
+    def __init__(
+        self,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        timeout: Optional[float] = None,
+        system_prompt: Optional[str] = None,
+        client: Optional[object] = None,
+    ) -> None:
+        self.provider = (provider or os.getenv("NORM_AGENT_LLM_PROVIDER") or "openai").lower()
+        self.model = model or os.getenv("NORM_AGENT_LLM_MODEL", "gpt-4o-mini")
+        timeout_env = os.getenv("NORM_AGENT_LLM_TIMEOUT")
+        self.timeout = timeout if timeout is not None else float(timeout_env) if timeout_env else 30.0
+        self.system_prompt = system_prompt or os.getenv(
+            "NORM_AGENT_SYSTEM_PROMPT",
+            "Du bist eine erfahrene TGA-Fachingenieurin und bewertest Normkonformität.",
         )
-    return "Keine relevanten Normvorgaben erkannt oder Text unvollständig."
+        self._client = client
+
+    def _ensure_client(self) -> object:
+        if self._client is not None:
+            return self._client
+
+        if self.provider == "openai":
+            try:
+                from openai import OpenAI  # type: ignore
+            except ImportError as exc:  # pragma: no cover - import error path
+                raise LLMConfigurationError("OpenAI SDK ist nicht installiert.") from exc
+
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise LLMConfigurationError("OPENAI_API_KEY ist nicht gesetzt.")
+
+            self._client = OpenAI(api_key=api_key)
+            return self._client
+
+        raise LLMConfigurationError(f"Nicht unterstützter LLM-Provider: {self.provider}")
+
+    def generate(self, prompt: str) -> str:
+        client = self._ensure_client()
+
+        if self.provider == "openai":
+            try:
+                response = client.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {"role": "system", "content": self.system_prompt},
+                        {"role": "user", "content": prompt},
+                    ],
+                    timeout=self.timeout,
+                )
+            except (TimeoutError, asyncio.TimeoutError) as exc:
+                raise LLMTimeoutError("LLM Anfrage hat das Zeitlimit überschritten.") from exc
+            except Exception as exc:  # pragma: no cover - depends on provider implementation
+                if exc.__class__.__name__ in {"RateLimitError", "RateLimitException"}:
+                    raise LLMRateLimitError("LLM Rate Limit erreicht.") from exc
+                raise
+
+            try:
+                return response.choices[0].message.content.strip()
+            except (AttributeError, IndexError) as exc:  # pragma: no cover - defensive
+                raise LLMClientError("Antwort des LLM konnte nicht interpretiert werden.") from exc
+
+        raise LLMConfigurationError(f"Nicht unterstützter LLM-Provider: {self.provider}")
+
+
+JSON_PATTERN = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def build_norm_check_prompt(project_type: str, trade: str, plan_text: str) -> str:
+    plan_text_clean = plan_text.strip()
+    prompt_template = """
+    Bewertet die Normkonformität eines TGA-Fachplanausschnitts.
+    Liefere ausschließlich eine JSON-Antwort mit den Schlüsseln
+    "norm_reference", "assessment" und "recommendation".
+
+    Projektkontext:
+    - Projekttyp: {project_type}
+    - Gewerk: {trade}
+
+    Plantext (Auszug):
+    <PLAN_TEXT>
+    {plan_text}
+    </PLAN_TEXT>
+
+    Anforderungen:
+    1. Ermittle die wichtigsten Normen/Vorschriften für den Kontext.
+    2. Bewerte ob die Planung die Norm erfüllt, inkl. kurzer Begründung.
+    3. Gib eine konkrete Empfehlung für nächste Schritte.
+    4. Falls keine Bewertung möglich ist, erläutere warum.
+    5. Formatiere als kompaktes JSON (keine zusätzlichen Texte).
+    """
+    return dedent(prompt_template).strip().format(
+        project_type=project_type.strip(),
+        trade=trade.strip(),
+        plan_text=plan_text_clean,
+    )
+
+
+def _extract_json(text: str) -> str:
+    match = JSON_PATTERN.search(text)
+    return match.group(0) if match else text
+
+
+def parse_norm_check_response(response: str) -> NormCheckResult:
+    json_payload = _extract_json(response.strip())
+
+    try:
+        data = json.loads(json_payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Antwort des LLM konnte nicht als JSON geparst werden.") from exc
+
+    norm_reference = (
+        data.get("norm_reference")
+        or data.get("norm")
+        or data.get("reference")
+        or "Unbekannt"
+    )
+    assessment = data.get("assessment") or data.get("evaluation") or "Keine Bewertung vorhanden."
+    recommendation = data.get("recommendation") or data.get("next_steps") or "Keine Empfehlung vorhanden."
+
+    return NormCheckResult(
+        norm_reference=str(norm_reference).strip(),
+        assessment=str(assessment).strip(),
+        recommendation=str(recommendation).strip(),
+    )
+
+
+def _map_llm_exception(exc: Exception) -> Optional[LLMClientError]:
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return LLMTimeoutError("LLM Anfrage hat das Zeitlimit überschritten.")
+
+    if exc.__class__.__name__ in {"RateLimitError", "RateLimitException"}:
+        return LLMRateLimitError("LLM Rate Limit erreicht.")
+
+    return None
+
+
+def _fallback_norm_check(plan_text: str) -> NormCheckResult:
+    if "Tiefgarage" in plan_text and "6/h" in plan_text:
+        return NormCheckResult(
+            norm_reference="VDI 2053 (Lüftung von Garagen)",
+            assessment="Geplanter Luftwechsel von 6/h erfüllt die Mindestanforderung >5/h.",
+            recommendation="CO-Sensoren prüfen und Wartungsintervall dokumentieren.",
+        )
+
+    return NormCheckResult(
+        norm_reference="Unbekannt",
+        assessment="Keine relevanten Normvorgaben erkannt oder Text unvollständig.",
+        recommendation="Bitte Projektdaten und Plantext ergänzen, um eine Bewertung zu ermöglichen.",
+    )
+
+
+def run_norm_check(
+    project_type: str,
+    trade: str,
+    plan_text: str,
+    llm_client: Optional[LLMClient] = None,
+) -> NormCheckResult:
+    prompt = build_norm_check_prompt(project_type, trade, plan_text)
+    client = llm_client or LLMClient()
+
+    try:
+        response_text = client.generate(prompt)
+    except LLMConfigurationError as exc:
+        logger.warning("LLM Konfiguration unvollständig, nutze Fallback: %s", exc)
+        return _fallback_norm_check(plan_text)
+    except LLMClientError:
+        raise
+    except Exception as exc:
+        mapped = _map_llm_exception(exc)
+        if mapped:
+            raise mapped from exc
+        raise
+
+    return parse_norm_check_response(response_text)

--- a/backend/routers/agent_tasks.py
+++ b/backend/routers/agent_tasks.py
@@ -6,9 +6,11 @@ from agent_core.norm_agent import run_norm_check
 router = APIRouter()
 
 class NormCheckRequest(BaseModel):
-    input_text: str
+    project_type: str
+    trade: str
+    plan_text: str
 
 @router.post("/normcheck")
 def norm_check_task(request: NormCheckRequest):
-    result = run_norm_check(request.input_text)
-    return {"result": result}
+    result = run_norm_check(request.project_type, request.trade, request.plan_text)
+    return {"result": result.to_dict()}

--- a/backend/tests/test_norm_agent.py
+++ b/backend/tests/test_norm_agent.py
@@ -1,0 +1,64 @@
+import pytest
+
+from backend.agent_core.norm_agent import (
+    LLMRateLimitError,
+    LLMTimeoutError,
+    NormCheckResult,
+    build_norm_check_prompt,
+    parse_norm_check_response,
+    run_norm_check,
+)
+
+
+def test_build_norm_check_prompt_structure():
+    prompt = build_norm_check_prompt("Bürogebäude", "Heizung", "Luftwechsel 6/h in Tiefgarage")
+
+    assert "Projekttyp: Bürogebäude" in prompt
+    assert "Gewerk: Heizung" in prompt
+    assert "Liefere ausschließlich eine JSON-Antwort" in prompt
+    assert "Plantext" in prompt
+
+
+def test_parse_norm_check_response_valid_json():
+    response = """{
+        "norm_reference": "VDI 2053",
+        "assessment": "Konform",
+        "recommendation": "Keine weiteren Maßnahmen erforderlich"
+    }"""
+
+    result = parse_norm_check_response(response)
+
+    assert isinstance(result, NormCheckResult)
+    assert result.norm_reference == "VDI 2053"
+    assert result.assessment == "Konform"
+    assert result.recommendation == "Keine weiteren Maßnahmen erforderlich"
+
+
+def test_parse_norm_check_response_embedded_json():
+    response = "Antwort:\n```json\n{\n  \"norm\": \"EN 12101\",\n  \"evaluation\": \"teilweise konform\",\n  \"next_steps\": \"Entrauchungskonzept nachschärfen\"\n}\n```"
+
+    result = parse_norm_check_response(response)
+
+    assert result.norm_reference == "EN 12101"
+    assert result.assessment == "teilweise konform"
+    assert result.recommendation == "Entrauchungskonzept nachschärfen"
+
+
+def test_run_norm_check_maps_timeout_to_custom_error():
+    class TimeoutClient:
+        def generate(self, prompt: str) -> str:  # pragma: no cover - executed in test
+            raise TimeoutError("request timed out")
+
+    with pytest.raises(LLMTimeoutError):
+        run_norm_check("Büro", "Lüftung", "Test", llm_client=TimeoutClient())
+
+
+def test_run_norm_check_maps_rate_limit_to_custom_error():
+    RateLimitError = type("RateLimitError", (Exception,), {})
+
+    class RateLimitClient:
+        def generate(self, prompt: str) -> str:  # pragma: no cover - executed in test
+            raise RateLimitError("rate limit")
+
+    with pytest.raises(LLMRateLimitError):
+        run_norm_check("Büro", "Lüftung", "Test", llm_client=RateLimitClient())


### PR DESCRIPTION
## Summary
- wrap norm agent interactions with a configurable LLM client and structured result parsing
- accept structured norm-check inputs in the router and return normalized payloads
- cover prompt generation, parsing, and error handling with new unit tests

## Testing
- pytest -q backend/tests/test_norm_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e120ff18d083248f0c53ab0b8d0dbf