### PR TITLE
Improve heating load unit handling and add low-load regression test

### DIFF
--- a/backend/agent_core/checks/kg420_heating.py
+++ b/backend/agent_core/checks/kg420_heating.py
@@ -55,11 +55,9 @@ def evaluate(context: Mapping[str, Any]) -> List[Finding]:
     if total_load is None:
         total_load = 0.0
         for room in rooms:
-            value = _to_float(room.get("heizlast"))
+            value = _normalize_room_load(room.get("heizlast"), room.get("heizlast_unit"))
             if value is None:
                 continue
-            if value > 1000:  # meist W → in kW umrechnen
-                value = value / 1000
             total_load += value
 
     for room in rooms:
@@ -324,6 +322,25 @@ def _to_float(value: Optional[Any]) -> Optional[float]:
             except ValueError:
                 return None
         return None
+
+
+def _normalize_room_load(value: Optional[Any], unit: Optional[Any]) -> Optional[float]:
+    numeric = _to_float(value)
+    if numeric is None:
+        return None
+
+    if isinstance(unit, str):
+        lowered = unit.lower()
+        if lowered.startswith("mw"):
+            return numeric * 1000
+        if lowered.startswith("kw"):
+            return numeric
+        if lowered.startswith("w"):
+            return numeric / 1000
+
+    if numeric > 1000:
+        return numeric / 1000
+    return numeric
 
 
 __all__ = ["evaluate", "GEWERK"]

--- a/backend/tests/test_kg420_heating.py
+++ b/backend/tests/test_kg420_heating.py
@@ -94,6 +94,32 @@ def test_specific_load_too_low_positive():
     assert "kg420_room_Raum A_niedrig" not in finding_ids(findings)
 
 
+def test_small_room_loads_in_watts_do_not_trigger_generator_warning():
+    context = base_context()
+    context["heating_load"]["rooms"] = [  # type: ignore[index]
+        {
+            "name": "Raum A",
+            "flaeche": 13.0,
+            "heizlast": 720.0,
+            "heizlast_unit": "W",
+            "spezifische_heizlast": 55.4,
+        },
+        {
+            "name": "Raum B",
+            "flaeche": 11.5,
+            "heizlast": 610.0,
+            "heizlast_unit": "W",
+            "spezifische_heizlast": 53.0,
+        },
+    ]
+    context["heating_load"]["total"] = None  # type: ignore[index]
+    context["generator"]["leistung"] = 6.0  # type: ignore[index]
+
+    findings = evaluate(context)
+
+    assert "kg420_erzeuger_001" not in finding_ids(findings)
+
+
 def test_supply_temperature_limit_negative():
     context = base_context()
     context["system"]["supply_temperature"] = 75.0  # type: ignore[index]


### PR DESCRIPTION
## Summary
- capture heating load units when parsing documents so downstream logic knows whether values are reported in watts or kilowatts
- update heating context normalization and generator evaluation to respect explicit units instead of relying on a single threshold
- add a regression test with sub-kilowatt room loads to ensure no spurious generator undersizing warning is emitted

## Testing
- pytest -q backend/tests/test_kg420_heating.py

------
https://chatgpt.com/codex/tasks/task_e_68e12d4d9bf88324b2f4c38627b19352