### PR TITLE
fix: harden knowledge chunk ingestion

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities for backend configuration."""
+
+from .config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,0 +1,79 @@
+"""Central configuration utilities for backend services."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+
+
+def _get_bool(value: Optional[str], default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _get_float(value: Optional[str], default: float) -> float:
+    try:
+        return float(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+def _get_int(value: Optional[str], default: int) -> int:
+    try:
+        return int(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration derived from environment variables."""
+
+    ollama_base_url: Optional[str]
+    ollama_embed_model: str
+    ollama_embed_timeout: float
+
+    openai_api_key: Optional[str]
+    openai_organization: Optional[str]
+    openai_base_url: str
+    openai_embed_model: str
+    openai_embed_timeout: float
+
+    rag_vector_dim: int
+    rag_collection_name: str
+    rag_auto_wipe_on_mismatch: bool
+
+    qdrant_url: Optional[str]
+    qdrant_api_key: Optional[str]
+    qdrant_timeout: float
+
+    test_mode: bool
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Returns cached application settings."""
+
+    return Settings(
+        ollama_base_url=os.getenv("OLLAMA_BASE_URL"),
+        ollama_embed_model=os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text"),
+        ollama_embed_timeout=_get_float(os.getenv("OLLAMA_EMBED_TIMEOUT"), 15.0),
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
+        openai_organization=os.getenv("OPENAI_ORGANIZATION"),
+        openai_base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+        openai_embed_model=os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small"),
+        openai_embed_timeout=_get_float(os.getenv("OPENAI_EMBED_TIMEOUT"), 15.0),
+        rag_vector_dim=_get_int(os.getenv("RAG_VECTOR_DIM"), 1536),
+        rag_collection_name=os.getenv("RAG_COLLECTION_NAME", "project_knowledge"),
+        rag_auto_wipe_on_mismatch=_get_bool(os.getenv("RAG_AUTO_WIPE_ON_MISMATCH"), False),
+        qdrant_url=os.getenv("QDRANT_URL"),
+        qdrant_api_key=os.getenv("QDRANT_API_KEY"),
+        qdrant_timeout=_get_float(os.getenv("QDRANT_TIMEOUT"), 5.0),
+        test_mode=_get_bool(os.getenv("TEST_MODE"), False),
+    )
+
+
+__all__ = ["Settings", "get_settings"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import agent_tasks, upload_router, flowcalc_tasks, tga_router
+from routers import agent_tasks, upload_router, flowcalc_tasks, tga_router, knowledge_router
 from database import init_db
 import logging
 
@@ -36,6 +36,7 @@ app.include_router(agent_tasks.router, prefix="/agent/tasks", tags=["Legacy Agen
 app.include_router(upload_router.router, prefix="/documents", tags=["Legacy Upload"])
 app.include_router(flowcalc_tasks.router, prefix="/agent/tasks", tags=["Legacy Flow Calc"])
 app.include_router(tga_router.router, prefix="/api/v1/tga", tags=["TGA Planprüfung"])
+app.include_router(knowledge_router.router)
 
 @app.get("/", tags=["System"])
 def root():

--- a/backend/routers/knowledge_router.py
+++ b/backend/routers/knowledge_router.py
@@ -1,0 +1,129 @@
+"""API endpoints for querying project knowledge chunks."""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models import KnowledgeChunk, KnowledgeChunkTypeEnum
+from backend.services.anonymization import TextSanitizer
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/projects", tags=["Knowledge"])
+
+
+class KnowledgeChunkResponse(BaseModel):
+    chunk_id: str
+    dokument_id: str
+    chunk_type: str
+    chunk_text: str
+    score: float
+    source_reference: Optional[dict]
+
+
+class KnowledgeSearchRequest(BaseModel):
+    query: str
+    top_k: int = 5
+    chunk_types: Optional[List[str]] = None
+
+
+class KnowledgeSearchResponse(BaseModel):
+    projekt_id: str
+    query: str
+    results: List[KnowledgeChunkResponse]
+
+
+@router.get("/{projekt_id}/knowledge/chunks", response_model=List[KnowledgeChunkResponse])
+def list_chunks(
+    projekt_id: str,
+    chunk_type: Optional[str] = Query(default=None, alias="type"),
+    db: Session = Depends(get_db),
+):
+    query = db.query(KnowledgeChunk).filter(KnowledgeChunk.projekt_id == projekt_id)
+
+    if chunk_type:
+        try:
+            chunk_type_enum = KnowledgeChunkTypeEnum(chunk_type)
+        except ValueError as exc:  # pragma: no cover - validation
+            raise HTTPException(status_code=400, detail=f"Ungültiger Chunk-Typ: {chunk_type}") from exc
+        query = query.filter(KnowledgeChunk.chunk_type == chunk_type_enum)
+
+    sanitizer = TextSanitizer()
+    results = []
+
+    for chunk in query.order_by(KnowledgeChunk.chunk_index.asc()).limit(200):
+        sanitized = sanitizer.sanitize(chunk.chunk_text)
+        results.append(
+            KnowledgeChunkResponse(
+                chunk_id=chunk.id,
+                dokument_id=chunk.dokument_id,
+                chunk_type=chunk.chunk_type.value,
+                chunk_text=sanitized.sanitized_text,
+                score=1.0,
+                source_reference=chunk.source_reference or {},
+            )
+        )
+
+    return results
+
+
+@router.post("/{projekt_id}/knowledge/search", response_model=KnowledgeSearchResponse)
+def search_chunks(
+    projekt_id: str,
+    request: KnowledgeSearchRequest,
+    db: Session = Depends(get_db),
+):
+    if not request.query.strip():
+        raise HTTPException(status_code=400, detail="Suchanfrage darf nicht leer sein.")
+
+    allowed_types: Optional[List[KnowledgeChunkTypeEnum]] = None
+    if request.chunk_types:
+        allowed_types = []
+        for chunk_type in request.chunk_types:
+            try:
+                allowed_types.append(KnowledgeChunkTypeEnum(chunk_type))
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=f"Ungültiger Chunk-Typ: {chunk_type}") from exc
+
+    query = db.query(KnowledgeChunk).filter(KnowledgeChunk.projekt_id == projekt_id)
+    if allowed_types:
+        query = query.filter(KnowledgeChunk.chunk_type.in_(allowed_types))
+
+    chunks = query.all()
+    sanitizer = TextSanitizer()
+
+    scored = []
+    needle = request.query.lower()
+    for chunk in chunks:
+        haystack = (chunk.chunk_text or "").lower()
+        if not haystack:
+            continue
+        occurrences = haystack.count(needle)
+        if occurrences == 0 and needle not in haystack:
+            continue
+        score = occurrences if occurrences > 0 else 0.5
+        sanitized = sanitizer.sanitize(chunk.chunk_text)
+        scored.append(
+            KnowledgeChunkResponse(
+                chunk_id=chunk.id,
+                dokument_id=chunk.dokument_id,
+                chunk_type=chunk.chunk_type.value,
+                chunk_text=sanitized.sanitized_text,
+                score=score,
+                source_reference=chunk.source_reference or {},
+            )
+        )
+
+    scored.sort(key=lambda item: item.score, reverse=True)
+    limited = scored[: max(request.top_k, 1)]
+
+    logger.info("Knowledge-Suche für Projekt %s mit %s Ergebnissen", projekt_id, len(limited))
+
+    return KnowledgeSearchResponse(projekt_id=projekt_id, query=request.query, results=limited)

--- a/backend/services/anonymization.py
+++ b/backend/services/anonymization.py
@@ -1,0 +1,137 @@
+"""Utility functions for sanitizing sensitive information before LLM calls."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+from typing import Dict, List
+
+
+logger = logging.getLogger(__name__)
+
+
+PERSON_PATTERN = re.compile(r"\b([A-ZÄÖÜ][a-zäöüß]+\s+[A-ZÄÖÜ][a-zäöüß]+)\b")
+COMPANY_PATTERN = re.compile(r"\b([A-ZÄÖÜ][\wäöüß\.-]*\s+(?:GmbH|AG|KG|UG|mbH))\b")
+LOCATION_PATTERN = re.compile(r"\b(\d{5}\s+[A-ZÄÖÜ][a-zäöüß]+)\b")
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_PATTERN = re.compile(r"\b(?:\+?\d{2,3}[\s-]?)?(?:\d{2,4}[\s/-]?){2,4}\d\b")
+
+
+@dataclasses.dataclass
+class SanitizationResult:
+    """Represents the outcome of a sanitization run."""
+
+    sanitized_text: str
+    replacements: Dict[str, str]
+    detected_entities: List[str]
+    compliance_ok: bool = True
+
+    def restore(self, text: str) -> str:
+        """Reapplies stored replacements to restore the original content."""
+
+        restored = text
+        for placeholder, original in self.replacements.items():
+            restored = restored.replace(placeholder, original)
+        return restored
+
+
+class TextSanitizer:
+    """Sanitizes free-form text by removing personal or company references."""
+
+    def __init__(self) -> None:
+        self._patterns: List[tuple[str, re.Pattern[str]]] = [
+            ("PERSON", PERSON_PATTERN),
+            ("COMPANY", COMPANY_PATTERN),
+            ("LOCATION", LOCATION_PATTERN),
+        ]
+
+    def sanitize(self, text: str) -> SanitizationResult:
+        """Sanitizes a text body and returns the sanitized representation."""
+
+        replacements: Dict[str, str] = {}
+        detected_entities: List[str] = []
+        sanitized = text
+        counter: Dict[str, int] = {key: 1 for key, _ in self._patterns}
+
+        for key, pattern in self._patterns:
+            sanitized = self._substitute_pattern(
+                sanitized,
+                pattern,
+                key,
+                counter,
+                replacements,
+                detected_entities,
+            )
+
+        # Emails and phone numbers are handled separately to avoid overlaps.
+        sanitized = self._replace_with_placeholder(
+            sanitized,
+            EMAIL_PATTERN,
+            "EMAIL",
+            replacements,
+            detected_entities,
+        )
+        sanitized = self._replace_with_placeholder(
+            sanitized,
+            PHONE_PATTERN,
+            "PHONE",
+            replacements,
+            detected_entities,
+        )
+
+        compliance_ok = not (EMAIL_PATTERN.search(sanitized) or PHONE_PATTERN.search(sanitized))
+
+        if not compliance_ok:
+            logger.warning("Sanitizer konnte sensible Daten nicht vollständig entfernen.")
+
+        return SanitizationResult(
+            sanitized_text=sanitized,
+            replacements=replacements,
+            detected_entities=detected_entities,
+            compliance_ok=compliance_ok,
+        )
+
+    def _substitute_pattern(
+        self,
+        text: str,
+        pattern: re.Pattern[str],
+        key: str,
+        counter: Dict[str, int],
+        replacements: Dict[str, str],
+        detected_entities: List[str],
+    ) -> str:
+        """Replaces pattern occurrences with placeholders."""
+
+        def _replace(match: re.Match[str]) -> str:
+            original = match.group(0)
+            placeholder = f"{key}_{counter[key]}"
+            counter[key] += 1
+            replacements[placeholder] = original
+            detected_entities.append(f"{key}:{original}")
+            return placeholder
+
+        return pattern.sub(_replace, text)
+
+    def _replace_with_placeholder(
+        self,
+        text: str,
+        pattern: re.Pattern[str],
+        key: str,
+        replacements: Dict[str, str],
+        detected_entities: List[str],
+    ) -> str:
+        """Utility to replace a pattern and record the replacements."""
+
+        counter = 1
+
+        def _replace(match: re.Match[str]) -> str:
+            nonlocal counter
+            original = match.group(0)
+            placeholder = f"{key}_{counter}"
+            counter += 1
+            replacements[placeholder] = original
+            detected_entities.append(f"{key}:{original}")
+            return placeholder
+
+        return pattern.sub(_replace, text)

--- a/backend/services/knowledge_service.py
+++ b/backend/services/knowledge_service.py
@@ -1,0 +1,175 @@
+"""Services for building and managing knowledge chunks from parsed documents."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING
+
+from backend.services.rag_service import EmbeddingService, EmbeddingServiceError, serialize_embedding
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+    from backend.models import (
+        Dokument as DokumentModel,
+        DokumentMetadata as DokumentMetadataModel,
+        KnowledgeChunk as KnowledgeChunkModel,
+        KnowledgeChunkTypeEnum as KnowledgeChunkTypeEnum,
+    )
+
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeBuilder:
+    """Creates structured knowledge chunks from parsed document metadata."""
+
+    def __init__(
+        self,
+        db: Any,
+        embedding_service: Optional[EmbeddingService] = None,
+        max_chunk_chars: int = 1200,
+        chunk_overlap: int = 150,
+    ) -> None:
+        self.db = db
+        self.embedding_service = embedding_service or EmbeddingService.from_env()
+        self.max_chunk_chars = max_chunk_chars
+        self.chunk_overlap = chunk_overlap
+
+    def build_chunks(
+        self,
+        dokument: "DokumentModel",
+        metadata: Optional["DokumentMetadataModel"],
+    ) -> List["KnowledgeChunkModel"]:
+        """Generates chunk objects without persisting them."""
+
+        from backend.models import KnowledgeChunkTypeEnum
+
+        if metadata is None:
+            logger.debug("Keine Metadaten für Dokument %s verfügbar – Knowledge-Building übersprungen.", dokument.id)
+            return []
+
+        chunk_index = 0
+        chunks: List[KnowledgeChunk] = []
+
+        for text_chunk in self._split_text(metadata.extrahierter_text or ""):
+            if not text_chunk.strip():
+                continue
+            chunk = self._create_chunk(
+                dokument=dokument,
+                chunk_index=chunk_index,
+                chunk_type=KnowledgeChunkTypeEnum.TEXT,
+                chunk_text=text_chunk,
+                source_reference={"source": "text"},
+            )
+            chunks.append(chunk)
+            chunk_index += 1
+
+        for table_chunk in self._iter_table_chunks(metadata.tabellen_daten or []):
+            chunk = self._create_chunk(
+                dokument=dokument,
+                chunk_index=chunk_index,
+                chunk_type=KnowledgeChunkTypeEnum.TABLE,
+                chunk_text=table_chunk["text"],
+                source_reference=table_chunk["metadata"],
+            )
+            chunks.append(chunk)
+            chunk_index += 1
+
+        logger.info("%s Wissenseinträge für Dokument %s erzeugt", len(chunks), dokument.id)
+        return chunks
+
+    def persist_chunks(self, chunks: Iterable["KnowledgeChunkModel"]) -> None:
+        """Persists the provided chunk objects within the associated session."""
+
+        for chunk in chunks:
+            self.db.add(chunk)
+
+    def _create_chunk(
+        self,
+        dokument: "DokumentModel",
+        chunk_index: int,
+        chunk_type: "KnowledgeChunkTypeEnum",
+        chunk_text: str,
+        source_reference: Optional[Dict[str, object]] = None,
+    ) -> "KnowledgeChunkModel":
+        from backend.models import KnowledgeChunk
+
+        embedding_vector: Optional[List[float]] = None
+        embedding_model: Optional[str] = None
+
+        if self.embedding_service:
+            try:
+                response = self.embedding_service.generate(chunk_text)
+                embedding_vector = response.vector
+                embedding_model = response.model
+            except EmbeddingServiceError as exc:
+                logger.warning("Embedding-Generierung fehlgeschlagen: %s", exc)
+        else:
+            logger.debug("Kein Embedding-Service konfiguriert – Chunks werden ohne Vektor gespeichert.")
+
+        chunk = KnowledgeChunk(
+            projekt_id=dokument.projekt_id,
+            dokument_id=dokument.id,
+            chunk_index=chunk_index,
+            chunk_type=chunk_type,
+            chunk_text=chunk_text.strip(),
+            source_reference=source_reference or {},
+            embedding_model=embedding_model,
+            embedding_vector=serialize_embedding(embedding_vector),
+            embedding_dimensions=len(embedding_vector) if embedding_vector else None,
+        )
+        return chunk
+
+    def _split_text(self, text: str) -> List[str]:
+        if not text:
+            return []
+
+        normalized = " ".join(text.split())
+        if len(normalized) <= self.max_chunk_chars:
+            return [normalized]
+
+        if self.chunk_overlap >= self.max_chunk_chars:
+            raise ValueError("chunk_overlap must be smaller than max_chunk_chars")
+
+        chunks: List[str] = []
+        start = 0
+        text_length = len(normalized)
+
+        while start < text_length:
+            end = min(start + self.max_chunk_chars, text_length)
+            chunk = normalized[start:end]
+            if chunk:
+                chunks.append(chunk)
+
+            if end >= text_length:
+                break
+
+            start = max(end - self.chunk_overlap, 0)
+
+        return chunks
+
+    def _iter_table_chunks(self, tabellen_daten: Iterable[dict]) -> Iterable[Dict[str, object]]:
+        for index, table in enumerate(tabellen_daten):
+            headers = table.get("headers") or []
+            rows = table.get("rows") or table.get("data") or []
+
+            if not rows:
+                continue
+
+            lines = []
+            if headers:
+                lines.append(" | ".join(str(h) for h in headers))
+
+            for row in rows:
+                if isinstance(row, dict):
+                    row_values = [str(row.get(h, "")) for h in headers]
+                else:
+                    row_values = [str(cell) for cell in row]
+                lines.append(" | ".join(row_values))
+
+            table_text = "\n".join(lines)
+
+            yield {
+                "text": table_text,
+                "metadata": {"source": "table", "table_index": index, "headers": headers},
+            }

--- a/backend/services/knowledge_service.py
+++ b/backend/services/knowledge_service.py
@@ -1,11 +1,18 @@
-"""Services for building and managing knowledge chunks from parsed documents."""
+"""Services for building and persisting project knowledge chunks."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Protocol, Sequence, TYPE_CHECKING
 
-from backend.services.rag_service import EmbeddingService, EmbeddingServiceError, serialize_embedding
+from backend.core.config import Settings, get_settings
+from backend.services.rag_service import (
+    EmbeddingService,
+    EmbeddingServiceError,
+    deserialize_embedding,
+    serialize_embedding,
+)
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers only
@@ -20,6 +27,24 @@ if TYPE_CHECKING:  # pragma: no cover - typing helpers only
 logger = logging.getLogger(__name__)
 
 
+class VectorStore(Protocol):
+    """Protocol describing the vector store interface used by knowledge sync."""
+
+    def ensure_collection(self, vector_dim: int) -> None:  # pragma: no cover - interface
+        ...
+
+    def upsert_embeddings(self, points: Sequence[Dict[str, Any]]) -> None:  # pragma: no cover - interface
+        ...
+
+
+@dataclass
+class ChunkDraft:
+    chunk_index: int
+    chunk_type: "KnowledgeChunkTypeEnum"
+    chunk_text: str
+    source_reference: Dict[str, Any]
+
+
 class KnowledgeBuilder:
     """Creates structured knowledge chunks from parsed document metadata."""
 
@@ -27,62 +52,102 @@ class KnowledgeBuilder:
         self,
         db: Any,
         embedding_service: Optional[EmbeddingService] = None,
+        *,
+        vector_store: Optional[VectorStore] = None,
         max_chunk_chars: int = 1200,
         chunk_overlap: int = 150,
+        settings: Optional[Settings] = None,
     ) -> None:
         self.db = db
+        self.settings = settings or get_settings()
         self.embedding_service = embedding_service or EmbeddingService.from_env()
+        self.vector_store = vector_store
         self.max_chunk_chars = max_chunk_chars
         self.chunk_overlap = chunk_overlap
+
+        if self.chunk_overlap < 0:
+            raise ValueError("chunk_overlap must be non-negative")
 
     def build_chunks(
         self,
         dokument: "DokumentModel",
         metadata: Optional["DokumentMetadataModel"],
     ) -> List["KnowledgeChunkModel"]:
-        """Generates chunk objects without persisting them."""
+        """Generates chunk model instances without persisting them."""
 
-        from backend.models import KnowledgeChunkTypeEnum
+        from backend.models import KnowledgeChunk, KnowledgeChunkTypeEnum
 
         if metadata is None:
-            logger.debug("Keine Metadaten für Dokument %s verfügbar – Knowledge-Building übersprungen.", dokument.id)
+            logger.debug(
+                "Keine Metadaten für Dokument %s verfügbar – Knowledge-Building übersprungen.",
+                dokument.id,
+            )
             return []
 
-        chunk_index = 0
+        drafts = list(self._iter_drafts(metadata))
         chunks: List[KnowledgeChunk] = []
 
-        for text_chunk in self._split_text(metadata.extrahierter_text or ""):
-            if not text_chunk.strip():
-                continue
+        for draft in drafts:
             chunk = self._create_chunk(
                 dokument=dokument,
-                chunk_index=chunk_index,
-                chunk_type=KnowledgeChunkTypeEnum.TEXT,
-                chunk_text=text_chunk,
-                source_reference={"source": "text"},
+                chunk_index=draft.chunk_index,
+                chunk_type=draft.chunk_type,
+                chunk_text=draft.chunk_text,
+                source_reference=draft.source_reference,
             )
-            chunks.append(chunk)
-            chunk_index += 1
-
-        for table_chunk in self._iter_table_chunks(metadata.tabellen_daten or []):
-            chunk = self._create_chunk(
-                dokument=dokument,
-                chunk_index=chunk_index,
-                chunk_type=KnowledgeChunkTypeEnum.TABLE,
-                chunk_text=table_chunk["text"],
-                source_reference=table_chunk["metadata"],
-            )
-            chunks.append(chunk)
-            chunk_index += 1
+            if chunk is not None:
+                chunks.append(chunk)
 
         logger.info("%s Wissenseinträge für Dokument %s erzeugt", len(chunks), dokument.id)
         return chunks
 
-    def persist_chunks(self, chunks: Iterable["KnowledgeChunkModel"]) -> None:
-        """Persists the provided chunk objects within the associated session."""
+    def persist_chunks(self, chunks: Iterable["KnowledgeChunkModel"]) -> List["KnowledgeChunkModel"]:
+        """Persists the provided chunk objects and returns them."""
 
+        persisted: List["KnowledgeChunkModel"] = []
         for chunk in chunks:
             self.db.add(chunk)
+            persisted.append(chunk)
+
+        if not persisted:
+            return []
+
+        # Ensure IDs are assigned before syncing with the vector store
+        if hasattr(self.db, "flush"):
+            self.db.flush()
+
+        self._sync_vector_store(persisted)
+        return persisted
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _iter_drafts(self, metadata: "DokumentMetadataModel") -> Iterator[ChunkDraft]:
+        from backend.models import KnowledgeChunkTypeEnum
+
+        chunk_index = 0
+
+        for text_chunk in self._split_text(metadata.extrahierter_text or ""):
+            if not text_chunk.strip():
+                continue
+            yield ChunkDraft(
+                chunk_index=chunk_index,
+                chunk_type=KnowledgeChunkTypeEnum.TEXT,
+                chunk_text=text_chunk.strip(),
+                source_reference={"source": "text"},
+            )
+            chunk_index += 1
+
+        for table_chunk in self._iter_table_chunks(metadata.tabellen_daten or []):
+            if not table_chunk["text"].strip():
+                continue
+            yield ChunkDraft(
+                chunk_index=chunk_index,
+                chunk_type=KnowledgeChunkTypeEnum.TABLE,
+                chunk_text=table_chunk["text"].strip(),
+                source_reference=table_chunk["metadata"],
+            )
+            chunk_index += 1
 
     def _create_chunk(
         self,
@@ -90,33 +155,33 @@ class KnowledgeBuilder:
         chunk_index: int,
         chunk_type: "KnowledgeChunkTypeEnum",
         chunk_text: str,
-        source_reference: Optional[Dict[str, object]] = None,
-    ) -> "KnowledgeChunkModel":
+        source_reference: Optional[Dict[str, Any]] = None,
+    ) -> Optional["KnowledgeChunkModel"]:
         from backend.models import KnowledgeChunk
 
         embedding_vector: Optional[List[float]] = None
         embedding_model: Optional[str] = None
+        embedding_dimensions: Optional[int] = None
 
         if self.embedding_service:
             try:
                 response = self.embedding_service.generate(chunk_text)
                 embedding_vector = response.vector
                 embedding_model = response.model
+                embedding_dimensions = response.dimensions
             except EmbeddingServiceError as exc:
                 logger.warning("Embedding-Generierung fehlgeschlagen: %s", exc)
-        else:
-            logger.debug("Kein Embedding-Service konfiguriert – Chunks werden ohne Vektor gespeichert.")
 
         chunk = KnowledgeChunk(
             projekt_id=dokument.projekt_id,
             dokument_id=dokument.id,
             chunk_index=chunk_index,
             chunk_type=chunk_type,
-            chunk_text=chunk_text.strip(),
+            chunk_text=chunk_text,
             source_reference=source_reference or {},
             embedding_model=embedding_model,
             embedding_vector=serialize_embedding(embedding_vector),
-            embedding_dimensions=len(embedding_vector) if embedding_vector else None,
+            embedding_dimensions=embedding_dimensions,
         )
         return chunk
 
@@ -148,7 +213,7 @@ class KnowledgeBuilder:
 
         return chunks
 
-    def _iter_table_chunks(self, tabellen_daten: Iterable[dict]) -> Iterable[Dict[str, object]]:
+    def _iter_table_chunks(self, tabellen_daten: Iterable[dict]) -> Iterator[Dict[str, Any]]:
         for index, table in enumerate(tabellen_daten):
             headers = table.get("headers") or []
             rows = table.get("rows") or table.get("data") or []
@@ -156,7 +221,7 @@ class KnowledgeBuilder:
             if not rows:
                 continue
 
-            lines = []
+            lines: List[str] = []
             if headers:
                 lines.append(" | ".join(str(h) for h in headers))
 
@@ -167,9 +232,56 @@ class KnowledgeBuilder:
                     row_values = [str(cell) for cell in row]
                 lines.append(" | ".join(row_values))
 
+            if not lines:
+                continue
+
             table_text = "\n".join(lines)
 
             yield {
                 "text": table_text,
                 "metadata": {"source": "table", "table_index": index, "headers": headers},
             }
+
+    def _sync_vector_store(self, chunks: Sequence["KnowledgeChunkModel"]) -> None:
+        if not self.vector_store:
+            return
+
+        vectors: List[Dict[str, Any]] = []
+        for chunk in chunks:
+            if not chunk.embedding_vector:
+                continue
+            vector = deserialize_embedding(chunk.embedding_vector)
+            if not vector:
+                continue
+            vectors.append(
+                {
+                    "id": chunk.id,
+                    "vector": vector,
+                    "payload": {
+                        "projekt_id": chunk.projekt_id,
+                        "dokument_id": chunk.dokument_id,
+                        "chunk_index": chunk.chunk_index,
+                        "chunk_type": chunk.chunk_type.value,
+                        "source_reference": chunk.source_reference,
+                    },
+                }
+            )
+
+        if not vectors:
+            return
+
+        vector_dim = len(vectors[0]["vector"])
+
+        try:
+            self.vector_store.ensure_collection(vector_dim)
+        except Exception as exc:  # pragma: no cover - external service failure
+            logger.warning("Vectorstore-Synchronisierung übersprungen: %s", exc)
+            return
+
+        try:
+            self.vector_store.upsert_embeddings(vectors)
+        except Exception as exc:  # pragma: no cover - external service failure
+            logger.warning("Vectorstore-Upsert fehlgeschlagen: %s", exc)
+
+
+__all__ = ["KnowledgeBuilder", "VectorStore", "ChunkDraft"]

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -1,0 +1,116 @@
+"""Services for embedding generation and knowledge retrieval support."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingServiceError(RuntimeError):
+    """Base error for embedding service failures."""
+
+
+@dataclass
+class EmbeddingResponse:
+    vector: List[float]
+    model: str
+
+
+class EmbeddingService:
+    """Simple wrapper for generating embeddings via Ollama's REST API."""
+
+    def __init__(self, base_url: str, model_name: str, timeout: float = 15.0) -> None:
+        if not base_url:
+            raise ValueError("base_url darf nicht leer sein")
+
+        self.base_url = base_url.rstrip("/")
+        self.model_name = model_name
+        self.timeout = timeout
+
+    @classmethod
+    def from_env(cls) -> Optional["EmbeddingService"]:
+        """Factory that builds a service instance from environment variables."""
+
+        base_url = os.getenv("OLLAMA_BASE_URL")
+        if not base_url:
+            return None
+
+        model = os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text")
+        timeout_env = os.getenv("OLLAMA_EMBED_TIMEOUT")
+        timeout = float(timeout_env) if timeout_env else 15.0
+        try:
+            return cls(base_url=base_url, model_name=model, timeout=timeout)
+        except ValueError:
+            logger.warning("EmbeddingService konnte nicht initialisiert werden (fehlende Konfiguration).")
+            return None
+
+    def generate(self, text: str) -> EmbeddingResponse:
+        """Generates an embedding for the provided text."""
+
+        endpoint = f"{self.base_url}/api/embeddings"
+        payload = {"model": self.model_name, "prompt": text}
+
+        if importlib.util.find_spec("requests") is None:
+            raise EmbeddingServiceError("Das 'requests'-Paket wird für Embedding-Aufrufe benötigt.")
+
+        requests_module = importlib.import_module("requests")
+
+        try:
+            response = requests_module.post(endpoint, json=payload, timeout=self.timeout)
+        except requests_module.RequestException as exc:  # pragma: no cover - network issues
+            raise EmbeddingServiceError("Verbindung zum Ollama Embedding-Service fehlgeschlagen.") from exc
+
+        if response.status_code >= 400:
+            raise EmbeddingServiceError(
+                f"Embedding-Service antwortete mit Status {response.status_code}: {response.text}"
+            )
+
+        data = response.json()
+        vector = self._extract_vector(data)
+        return EmbeddingResponse(vector=vector, model=self.model_name)
+
+    @staticmethod
+    def _extract_vector(payload: dict) -> List[float]:
+        """Extracts the embedding vector from an Ollama response."""
+
+        if "embedding" in payload:
+            return list(payload["embedding"])  # type: ignore[arg-type]
+
+        if "embeddings" in payload and payload["embeddings"]:
+            return list(payload["embeddings"][0])  # type: ignore[index]
+
+        raise EmbeddingServiceError("Embedding-Vektor im Ollama-Response nicht gefunden.")
+
+
+def serialize_embedding(vector: Optional[List[float]]) -> Optional[str]:
+    """Serializes an embedding vector for persistence."""
+
+    if vector is None:
+        return None
+
+    return json.dumps(vector)
+
+
+def deserialize_embedding(payload: Optional[str]) -> Optional[List[float]]:
+    """Deserializes an embedding vector from the database."""
+
+    if not payload:
+        return None
+
+    try:
+        loaded = json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise EmbeddingServiceError("Gespeicherter Embedding-Vektor ist kein gültiges JSON.") from exc
+
+    if not isinstance(loaded, list):
+        raise EmbeddingServiceError("Gespeicherter Embedding-Vektor hat ein ungültiges Format.")
+
+    return [float(x) for x in loaded]

--- a/backend/tests/test_knowledge_service.py
+++ b/backend/tests/test_knowledge_service.py
@@ -1,11 +1,57 @@
+import sys
+from types import SimpleNamespace
+
 import pytest
 
+from backend.core.config import get_settings
 from backend.services.knowledge_service import KnowledgeBuilder
+from backend.services.rag_service import EmbeddingService, EmbeddingServiceError
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_models(monkeypatch):
+    class FakeChunk:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+            self.id = kwargs.get("id", f"chunk-{kwargs.get('chunk_index', 0)}")
+
+    fake_enum = SimpleNamespace(
+        TEXT=SimpleNamespace(value="text"),
+        TABLE=SimpleNamespace(value="table"),
+    )
+
+    stub_module = SimpleNamespace(KnowledgeChunk=FakeChunk, KnowledgeChunkTypeEnum=fake_enum)
+    monkeypatch.setitem(sys.modules, "backend.models", stub_module)
+    yield stub_module
 
 
 class DummySession:
-    def add(self, obj):  # pragma: no cover - required by interface
-        pass
+    def __init__(self) -> None:
+        self.added = []
+        self.flushed = False
+
+    def add(self, obj):  # pragma: no cover - simple container
+        self.added.append(obj)
+
+    def flush(self):  # pragma: no cover - simple container
+        self.flushed = True
+
+
+class FakeEmbeddingService:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def generate(self, text: str):
+        self.calls.append(text)
+        return SimpleNamespace(vector=[0.1, 0.2], model="fake", dimensions=2)
 
 
 @pytest.mark.parametrize(
@@ -46,3 +92,50 @@ def test_split_text_rejects_invalid_overlap():
 
     with pytest.raises(ValueError):
         builder._split_text("abcdef")
+
+
+def test_persist_chunks_flushes_and_returns(stub_models):
+    session = DummySession()
+    builder = KnowledgeBuilder(db=session, embedding_service=FakeEmbeddingService())
+
+    dokument = SimpleNamespace(id="doc", projekt_id="proj")
+    chunk = builder._create_chunk(
+        dokument=dokument,
+        chunk_index=0,
+        chunk_type=stub_models.KnowledgeChunkTypeEnum.TEXT,
+        chunk_text="hello",
+        source_reference={"source": "test"},
+    )
+
+    persisted = builder.persist_chunks([chunk])
+
+    assert session.flushed is True
+    assert persisted[0].embedding_vector is not None
+
+
+def test_embedding_service_respects_test_mode(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    service = EmbeddingService.from_env()
+    assert service is not None
+
+    response = service.generate("Test eingabe")
+    assert response.model == "test/fake"
+    assert len(response.vector) == 8
+
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+
+def test_embedding_service_without_backend(monkeypatch):
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert EmbeddingService.from_env() is None
+
+    service = EmbeddingService()
+
+    with pytest.raises(EmbeddingServiceError):
+        service.generate("text")

--- a/backend/tests/test_knowledge_service.py
+++ b/backend/tests/test_knowledge_service.py
@@ -1,0 +1,48 @@
+import pytest
+
+from backend.services.knowledge_service import KnowledgeBuilder
+
+
+class DummySession:
+    def add(self, obj):  # pragma: no cover - required by interface
+        pass
+
+
+@pytest.mark.parametrize(
+    "text,chunk_size,overlap,expected",
+    [
+        (
+            "abcdefghijklmnop",
+            6,
+            2,
+            ["abcdef", "efghij", "ijklmn", "mnop"],
+        ),
+        (
+            "kurz",
+            10,
+            2,
+            ["kurz"],
+        ),
+    ],
+)
+def test_split_text_respects_overlap(text, chunk_size, overlap, expected):
+    builder = KnowledgeBuilder(
+        db=DummySession(),
+        embedding_service=None,
+        max_chunk_chars=chunk_size,
+        chunk_overlap=overlap,
+    )
+
+    assert builder._split_text(text) == expected
+
+
+def test_split_text_rejects_invalid_overlap():
+    builder = KnowledgeBuilder(
+        db=DummySession(),
+        embedding_service=None,
+        max_chunk_chars=5,
+        chunk_overlap=5,
+    )
+
+    with pytest.raises(ValueError):
+        builder._split_text("abcdef")


### PR DESCRIPTION
## Summary
- introduce knowledge chunk persistence and ingestion to build structured project context from parsed documents
- expose knowledge search endpoints with sanitized responses and configure Ollama-based embedding generation
- extend the NormAgent client with Gemini provider support and centralized text anonymization
- fix the knowledge chunk splitting logic to respect configured overlap and guard invalid settings with regression tests
- lazily load the requests dependency for the Ollama embedding client so optional installations do not break imports

## Testing
- pytest -q backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e133b62cd083249a74246e42f761b1