### PR TITLE
refactor: align knowledge ingestion with configurable embeddings

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities for backend configuration."""
+
+from .config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,0 +1,79 @@
+"""Central configuration utilities for backend services."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+
+
+def _get_bool(value: Optional[str], default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _get_float(value: Optional[str], default: float) -> float:
+    try:
+        return float(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+def _get_int(value: Optional[str], default: int) -> int:
+    try:
+        return int(value) if value is not None else default
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration derived from environment variables."""
+
+    ollama_base_url: Optional[str]
+    ollama_embed_model: str
+    ollama_embed_timeout: float
+
+    openai_api_key: Optional[str]
+    openai_organization: Optional[str]
+    openai_base_url: str
+    openai_embed_model: str
+    openai_embed_timeout: float
+
+    rag_vector_dim: int
+    rag_collection_name: str
+    rag_auto_wipe_on_mismatch: bool
+
+    qdrant_url: Optional[str]
+    qdrant_api_key: Optional[str]
+    qdrant_timeout: float
+
+    test_mode: bool
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Returns cached application settings."""
+
+    return Settings(
+        ollama_base_url=os.getenv("OLLAMA_BASE_URL"),
+        ollama_embed_model=os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text"),
+        ollama_embed_timeout=_get_float(os.getenv("OLLAMA_EMBED_TIMEOUT"), 15.0),
+        openai_api_key=os.getenv("OPENAI_API_KEY"),
+        openai_organization=os.getenv("OPENAI_ORGANIZATION"),
+        openai_base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+        openai_embed_model=os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small"),
+        openai_embed_timeout=_get_float(os.getenv("OPENAI_EMBED_TIMEOUT"), 15.0),
+        rag_vector_dim=_get_int(os.getenv("RAG_VECTOR_DIM"), 1536),
+        rag_collection_name=os.getenv("RAG_COLLECTION_NAME", "project_knowledge"),
+        rag_auto_wipe_on_mismatch=_get_bool(os.getenv("RAG_AUTO_WIPE_ON_MISMATCH"), False),
+        qdrant_url=os.getenv("QDRANT_URL"),
+        qdrant_api_key=os.getenv("QDRANT_API_KEY"),
+        qdrant_timeout=_get_float(os.getenv("QDRANT_TIMEOUT"), 5.0),
+        test_mode=_get_bool(os.getenv("TEST_MODE"), False),
+    )
+
+
+__all__ = ["Settings", "get_settings"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import agent_tasks, upload_router, flowcalc_tasks, tga_router
+from routers import agent_tasks, upload_router, flowcalc_tasks, tga_router, knowledge_router
 from database import init_db
 import logging
 
@@ -36,6 +36,7 @@ app.include_router(agent_tasks.router, prefix="/agent/tasks", tags=["Legacy Agen
 app.include_router(upload_router.router, prefix="/documents", tags=["Legacy Upload"])
 app.include_router(flowcalc_tasks.router, prefix="/agent/tasks", tags=["Legacy Flow Calc"])
 app.include_router(tga_router.router, prefix="/api/v1/tga", tags=["TGA Planprüfung"])
+app.include_router(knowledge_router.router)
 
 @app.get("/", tags=["System"])
 def root():

--- a/backend/routers/knowledge_router.py
+++ b/backend/routers/knowledge_router.py
@@ -1,0 +1,129 @@
+"""API endpoints for querying project knowledge chunks."""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.models import KnowledgeChunk, KnowledgeChunkTypeEnum
+from backend.services.anonymization import TextSanitizer
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/projects", tags=["Knowledge"])
+
+
+class KnowledgeChunkResponse(BaseModel):
+    chunk_id: str
+    dokument_id: str
+    chunk_type: str
+    chunk_text: str
+    score: float
+    source_reference: Optional[dict]
+
+
+class KnowledgeSearchRequest(BaseModel):
+    query: str
+    top_k: int = 5
+    chunk_types: Optional[List[str]] = None
+
+
+class KnowledgeSearchResponse(BaseModel):
+    projekt_id: str
+    query: str
+    results: List[KnowledgeChunkResponse]
+
+
+@router.get("/{projekt_id}/knowledge/chunks", response_model=List[KnowledgeChunkResponse])
+def list_chunks(
+    projekt_id: str,
+    chunk_type: Optional[str] = Query(default=None, alias="type"),
+    db: Session = Depends(get_db),
+):
+    query = db.query(KnowledgeChunk).filter(KnowledgeChunk.projekt_id == projekt_id)
+
+    if chunk_type:
+        try:
+            chunk_type_enum = KnowledgeChunkTypeEnum(chunk_type)
+        except ValueError as exc:  # pragma: no cover - validation
+            raise HTTPException(status_code=400, detail=f"Ungültiger Chunk-Typ: {chunk_type}") from exc
+        query = query.filter(KnowledgeChunk.chunk_type == chunk_type_enum)
+
+    sanitizer = TextSanitizer()
+    results = []
+
+    for chunk in query.order_by(KnowledgeChunk.chunk_index.asc()).limit(200):
+        sanitized = sanitizer.sanitize(chunk.chunk_text)
+        results.append(
+            KnowledgeChunkResponse(
+                chunk_id=chunk.id,
+                dokument_id=chunk.dokument_id,
+                chunk_type=chunk.chunk_type.value,
+                chunk_text=sanitized.sanitized_text,
+                score=1.0,
+                source_reference=chunk.source_reference or {},
+            )
+        )
+
+    return results
+
+
+@router.post("/{projekt_id}/knowledge/search", response_model=KnowledgeSearchResponse)
+def search_chunks(
+    projekt_id: str,
+    request: KnowledgeSearchRequest,
+    db: Session = Depends(get_db),
+):
+    if not request.query.strip():
+        raise HTTPException(status_code=400, detail="Suchanfrage darf nicht leer sein.")
+
+    allowed_types: Optional[List[KnowledgeChunkTypeEnum]] = None
+    if request.chunk_types:
+        allowed_types = []
+        for chunk_type in request.chunk_types:
+            try:
+                allowed_types.append(KnowledgeChunkTypeEnum(chunk_type))
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=f"Ungültiger Chunk-Typ: {chunk_type}") from exc
+
+    query = db.query(KnowledgeChunk).filter(KnowledgeChunk.projekt_id == projekt_id)
+    if allowed_types:
+        query = query.filter(KnowledgeChunk.chunk_type.in_(allowed_types))
+
+    chunks = query.all()
+    sanitizer = TextSanitizer()
+
+    scored = []
+    needle = request.query.lower()
+    for chunk in chunks:
+        haystack = (chunk.chunk_text or "").lower()
+        if not haystack:
+            continue
+        occurrences = haystack.count(needle)
+        if occurrences == 0 and needle not in haystack:
+            continue
+        score = occurrences if occurrences > 0 else 0.5
+        sanitized = sanitizer.sanitize(chunk.chunk_text)
+        scored.append(
+            KnowledgeChunkResponse(
+                chunk_id=chunk.id,
+                dokument_id=chunk.dokument_id,
+                chunk_type=chunk.chunk_type.value,
+                chunk_text=sanitized.sanitized_text,
+                score=score,
+                source_reference=chunk.source_reference or {},
+            )
+        )
+
+    scored.sort(key=lambda item: item.score, reverse=True)
+    limited = scored[: max(request.top_k, 1)]
+
+    logger.info("Knowledge-Suche für Projekt %s mit %s Ergebnissen", projekt_id, len(limited))
+
+    return KnowledgeSearchResponse(projekt_id=projekt_id, query=request.query, results=limited)

--- a/backend/services/anonymization.py
+++ b/backend/services/anonymization.py
@@ -1,0 +1,137 @@
+"""Utility functions for sanitizing sensitive information before LLM calls."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+from typing import Dict, List
+
+
+logger = logging.getLogger(__name__)
+
+
+PERSON_PATTERN = re.compile(r"\b([A-ZÄÖÜ][a-zäöüß]+\s+[A-ZÄÖÜ][a-zäöüß]+)\b")
+COMPANY_PATTERN = re.compile(r"\b([A-ZÄÖÜ][\wäöüß\.-]*\s+(?:GmbH|AG|KG|UG|mbH))\b")
+LOCATION_PATTERN = re.compile(r"\b(\d{5}\s+[A-ZÄÖÜ][a-zäöüß]+)\b")
+EMAIL_PATTERN = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_PATTERN = re.compile(r"\b(?:\+?\d{2,3}[\s-]?)?(?:\d{2,4}[\s/-]?){2,4}\d\b")
+
+
+@dataclasses.dataclass
+class SanitizationResult:
+    """Represents the outcome of a sanitization run."""
+
+    sanitized_text: str
+    replacements: Dict[str, str]
+    detected_entities: List[str]
+    compliance_ok: bool = True
+
+    def restore(self, text: str) -> str:
+        """Reapplies stored replacements to restore the original content."""
+
+        restored = text
+        for placeholder, original in self.replacements.items():
+            restored = restored.replace(placeholder, original)
+        return restored
+
+
+class TextSanitizer:
+    """Sanitizes free-form text by removing personal or company references."""
+
+    def __init__(self) -> None:
+        self._patterns: List[tuple[str, re.Pattern[str]]] = [
+            ("PERSON", PERSON_PATTERN),
+            ("COMPANY", COMPANY_PATTERN),
+            ("LOCATION", LOCATION_PATTERN),
+        ]
+
+    def sanitize(self, text: str) -> SanitizationResult:
+        """Sanitizes a text body and returns the sanitized representation."""
+
+        replacements: Dict[str, str] = {}
+        detected_entities: List[str] = []
+        sanitized = text
+        counter: Dict[str, int] = {key: 1 for key, _ in self._patterns}
+
+        for key, pattern in self._patterns:
+            sanitized = self._substitute_pattern(
+                sanitized,
+                pattern,
+                key,
+                counter,
+                replacements,
+                detected_entities,
+            )
+
+        # Emails and phone numbers are handled separately to avoid overlaps.
+        sanitized = self._replace_with_placeholder(
+            sanitized,
+            EMAIL_PATTERN,
+            "EMAIL",
+            replacements,
+            detected_entities,
+        )
+        sanitized = self._replace_with_placeholder(
+            sanitized,
+            PHONE_PATTERN,
+            "PHONE",
+            replacements,
+            detected_entities,
+        )
+
+        compliance_ok = not (EMAIL_PATTERN.search(sanitized) or PHONE_PATTERN.search(sanitized))
+
+        if not compliance_ok:
+            logger.warning("Sanitizer konnte sensible Daten nicht vollständig entfernen.")
+
+        return SanitizationResult(
+            sanitized_text=sanitized,
+            replacements=replacements,
+            detected_entities=detected_entities,
+            compliance_ok=compliance_ok,
+        )
+
+    def _substitute_pattern(
+        self,
+        text: str,
+        pattern: re.Pattern[str],
+        key: str,
+        counter: Dict[str, int],
+        replacements: Dict[str, str],
+        detected_entities: List[str],
+    ) -> str:
+        """Replaces pattern occurrences with placeholders."""
+
+        def _replace(match: re.Match[str]) -> str:
+            original = match.group(0)
+            placeholder = f"{key}_{counter[key]}"
+            counter[key] += 1
+            replacements[placeholder] = original
+            detected_entities.append(f"{key}:{original}")
+            return placeholder
+
+        return pattern.sub(_replace, text)
+
+    def _replace_with_placeholder(
+        self,
+        text: str,
+        pattern: re.Pattern[str],
+        key: str,
+        replacements: Dict[str, str],
+        detected_entities: List[str],
+    ) -> str:
+        """Utility to replace a pattern and record the replacements."""
+
+        counter = 1
+
+        def _replace(match: re.Match[str]) -> str:
+            nonlocal counter
+            original = match.group(0)
+            placeholder = f"{key}_{counter}"
+            counter += 1
+            replacements[placeholder] = original
+            detected_entities.append(f"{key}:{original}")
+            return placeholder
+
+        return pattern.sub(_replace, text)

--- a/backend/services/knowledge_service.py
+++ b/backend/services/knowledge_service.py
@@ -1,0 +1,287 @@
+"""Services for building and persisting project knowledge chunks."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Protocol, Sequence, TYPE_CHECKING
+
+from backend.core.config import Settings, get_settings
+from backend.services.rag_service import (
+    EmbeddingService,
+    EmbeddingServiceError,
+    deserialize_embedding,
+    serialize_embedding,
+)
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+    from backend.models import (
+        Dokument as DokumentModel,
+        DokumentMetadata as DokumentMetadataModel,
+        KnowledgeChunk as KnowledgeChunkModel,
+        KnowledgeChunkTypeEnum as KnowledgeChunkTypeEnum,
+    )
+
+
+logger = logging.getLogger(__name__)
+
+
+class VectorStore(Protocol):
+    """Protocol describing the vector store interface used by knowledge sync."""
+
+    def ensure_collection(self, vector_dim: int) -> None:  # pragma: no cover - interface
+        ...
+
+    def upsert_embeddings(self, points: Sequence[Dict[str, Any]]) -> None:  # pragma: no cover - interface
+        ...
+
+
+@dataclass
+class ChunkDraft:
+    chunk_index: int
+    chunk_type: "KnowledgeChunkTypeEnum"
+    chunk_text: str
+    source_reference: Dict[str, Any]
+
+
+class KnowledgeBuilder:
+    """Creates structured knowledge chunks from parsed document metadata."""
+
+    def __init__(
+        self,
+        db: Any,
+        embedding_service: Optional[EmbeddingService] = None,
+        *,
+        vector_store: Optional[VectorStore] = None,
+        max_chunk_chars: int = 1200,
+        chunk_overlap: int = 150,
+        settings: Optional[Settings] = None,
+    ) -> None:
+        self.db = db
+        self.settings = settings or get_settings()
+        self.embedding_service = embedding_service or EmbeddingService.from_env()
+        self.vector_store = vector_store
+        self.max_chunk_chars = max_chunk_chars
+        self.chunk_overlap = chunk_overlap
+
+        if self.chunk_overlap < 0:
+            raise ValueError("chunk_overlap must be non-negative")
+
+    def build_chunks(
+        self,
+        dokument: "DokumentModel",
+        metadata: Optional["DokumentMetadataModel"],
+    ) -> List["KnowledgeChunkModel"]:
+        """Generates chunk model instances without persisting them."""
+
+        from backend.models import KnowledgeChunk, KnowledgeChunkTypeEnum
+
+        if metadata is None:
+            logger.debug(
+                "Keine Metadaten für Dokument %s verfügbar – Knowledge-Building übersprungen.",
+                dokument.id,
+            )
+            return []
+
+        drafts = list(self._iter_drafts(metadata))
+        chunks: List[KnowledgeChunk] = []
+
+        for draft in drafts:
+            chunk = self._create_chunk(
+                dokument=dokument,
+                chunk_index=draft.chunk_index,
+                chunk_type=draft.chunk_type,
+                chunk_text=draft.chunk_text,
+                source_reference=draft.source_reference,
+            )
+            if chunk is not None:
+                chunks.append(chunk)
+
+        logger.info("%s Wissenseinträge für Dokument %s erzeugt", len(chunks), dokument.id)
+        return chunks
+
+    def persist_chunks(self, chunks: Iterable["KnowledgeChunkModel"]) -> List["KnowledgeChunkModel"]:
+        """Persists the provided chunk objects and returns them."""
+
+        persisted: List["KnowledgeChunkModel"] = []
+        for chunk in chunks:
+            self.db.add(chunk)
+            persisted.append(chunk)
+
+        if not persisted:
+            return []
+
+        # Ensure IDs are assigned before syncing with the vector store
+        if hasattr(self.db, "flush"):
+            self.db.flush()
+
+        self._sync_vector_store(persisted)
+        return persisted
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _iter_drafts(self, metadata: "DokumentMetadataModel") -> Iterator[ChunkDraft]:
+        from backend.models import KnowledgeChunkTypeEnum
+
+        chunk_index = 0
+
+        for text_chunk in self._split_text(metadata.extrahierter_text or ""):
+            if not text_chunk.strip():
+                continue
+            yield ChunkDraft(
+                chunk_index=chunk_index,
+                chunk_type=KnowledgeChunkTypeEnum.TEXT,
+                chunk_text=text_chunk.strip(),
+                source_reference={"source": "text"},
+            )
+            chunk_index += 1
+
+        for table_chunk in self._iter_table_chunks(metadata.tabellen_daten or []):
+            if not table_chunk["text"].strip():
+                continue
+            yield ChunkDraft(
+                chunk_index=chunk_index,
+                chunk_type=KnowledgeChunkTypeEnum.TABLE,
+                chunk_text=table_chunk["text"].strip(),
+                source_reference=table_chunk["metadata"],
+            )
+            chunk_index += 1
+
+    def _create_chunk(
+        self,
+        dokument: "DokumentModel",
+        chunk_index: int,
+        chunk_type: "KnowledgeChunkTypeEnum",
+        chunk_text: str,
+        source_reference: Optional[Dict[str, Any]] = None,
+    ) -> Optional["KnowledgeChunkModel"]:
+        from backend.models import KnowledgeChunk
+
+        embedding_vector: Optional[List[float]] = None
+        embedding_model: Optional[str] = None
+        embedding_dimensions: Optional[int] = None
+
+        if self.embedding_service:
+            try:
+                response = self.embedding_service.generate(chunk_text)
+                embedding_vector = response.vector
+                embedding_model = response.model
+                embedding_dimensions = response.dimensions
+            except EmbeddingServiceError as exc:
+                logger.warning("Embedding-Generierung fehlgeschlagen: %s", exc)
+
+        chunk = KnowledgeChunk(
+            projekt_id=dokument.projekt_id,
+            dokument_id=dokument.id,
+            chunk_index=chunk_index,
+            chunk_type=chunk_type,
+            chunk_text=chunk_text,
+            source_reference=source_reference or {},
+            embedding_model=embedding_model,
+            embedding_vector=serialize_embedding(embedding_vector),
+            embedding_dimensions=embedding_dimensions,
+        )
+        return chunk
+
+    def _split_text(self, text: str) -> List[str]:
+        if not text:
+            return []
+
+        normalized = " ".join(text.split())
+        if len(normalized) <= self.max_chunk_chars:
+            return [normalized]
+
+        if self.chunk_overlap >= self.max_chunk_chars:
+            raise ValueError("chunk_overlap must be smaller than max_chunk_chars")
+
+        chunks: List[str] = []
+        start = 0
+        text_length = len(normalized)
+
+        while start < text_length:
+            end = min(start + self.max_chunk_chars, text_length)
+            chunk = normalized[start:end]
+            if chunk:
+                chunks.append(chunk)
+
+            if end >= text_length:
+                break
+
+            start = max(end - self.chunk_overlap, 0)
+
+        return chunks
+
+    def _iter_table_chunks(self, tabellen_daten: Iterable[dict]) -> Iterator[Dict[str, Any]]:
+        for index, table in enumerate(tabellen_daten):
+            headers = table.get("headers") or []
+            rows = table.get("rows") or table.get("data") or []
+
+            if not rows:
+                continue
+
+            lines: List[str] = []
+            if headers:
+                lines.append(" | ".join(str(h) for h in headers))
+
+            for row in rows:
+                if isinstance(row, dict):
+                    row_values = [str(row.get(h, "")) for h in headers]
+                else:
+                    row_values = [str(cell) for cell in row]
+                lines.append(" | ".join(row_values))
+
+            if not lines:
+                continue
+
+            table_text = "\n".join(lines)
+
+            yield {
+                "text": table_text,
+                "metadata": {"source": "table", "table_index": index, "headers": headers},
+            }
+
+    def _sync_vector_store(self, chunks: Sequence["KnowledgeChunkModel"]) -> None:
+        if not self.vector_store:
+            return
+
+        vectors: List[Dict[str, Any]] = []
+        for chunk in chunks:
+            if not chunk.embedding_vector:
+                continue
+            vector = deserialize_embedding(chunk.embedding_vector)
+            if not vector:
+                continue
+            vectors.append(
+                {
+                    "id": chunk.id,
+                    "vector": vector,
+                    "payload": {
+                        "projekt_id": chunk.projekt_id,
+                        "dokument_id": chunk.dokument_id,
+                        "chunk_index": chunk.chunk_index,
+                        "chunk_type": chunk.chunk_type.value,
+                        "source_reference": chunk.source_reference,
+                    },
+                }
+            )
+
+        if not vectors:
+            return
+
+        vector_dim = len(vectors[0]["vector"])
+
+        try:
+            self.vector_store.ensure_collection(vector_dim)
+        except Exception as exc:  # pragma: no cover - external service failure
+            logger.warning("Vectorstore-Synchronisierung übersprungen: %s", exc)
+            return
+
+        try:
+            self.vector_store.upsert_embeddings(vectors)
+        except Exception as exc:  # pragma: no cover - external service failure
+            logger.warning("Vectorstore-Upsert fehlgeschlagen: %s", exc)
+
+
+__all__ = ["KnowledgeBuilder", "VectorStore", "ChunkDraft"]

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -1,0 +1,223 @@
+"""Embedding utilities and helpers for RAG pipelines."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from backend.core.config import Settings, get_settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingServiceError(RuntimeError):
+    """Raised when embedding generation fails."""
+
+
+@dataclass
+class EmbeddingResponse:
+    vector: List[float]
+    model: str
+    dimensions: int
+
+
+class EmbeddingService:
+    """Handles embedding creation with local-first fallback logic."""
+
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        *,
+        requests_module: Optional[object] = None,
+    ) -> None:
+        self.settings = settings or get_settings()
+        self._requests = requests_module
+
+    @classmethod
+    def from_env(cls) -> Optional["EmbeddingService"]:
+        """Factory that returns an instance if a backend is configured."""
+
+        settings = get_settings()
+        if not any(
+            [
+                settings.test_mode,
+                bool(settings.ollama_base_url),
+                bool(settings.openai_api_key),
+            ]
+        ):
+            return None
+        return cls(settings=settings)
+
+    def generate(self, text: str) -> EmbeddingResponse:
+        """Generate an embedding for the supplied text."""
+
+        if not text:
+            raise EmbeddingServiceError("Text für Embedding darf nicht leer sein.")
+
+        if self.settings.test_mode:
+            vector = self._fake_embedding(text)
+            return EmbeddingResponse(vector=vector, model="test/fake", dimensions=len(vector))
+
+        errors: List[str] = []
+
+        if self.settings.ollama_base_url:
+            try:
+                return self._generate_via_ollama(text)
+            except EmbeddingServiceError as exc:
+                errors.append(f"Ollama: {exc}")
+
+        if self.settings.openai_api_key:
+            try:
+                return self._generate_via_openai(text)
+            except EmbeddingServiceError as exc:
+                errors.append(f"OpenAI: {exc}")
+
+        if errors:
+            raise EmbeddingServiceError("; ".join(errors))
+
+        raise EmbeddingServiceError("Kein Embedding-Backend konfiguriert.")
+
+    # ------------------------------------------------------------------
+    # Backend implementations
+    # ------------------------------------------------------------------
+    def _generate_via_ollama(self, text: str) -> EmbeddingResponse:
+        endpoint = f"{self.settings.ollama_base_url.rstrip('/')}/api/embeddings"
+        payload = {"model": self.settings.ollama_embed_model, "prompt": text}
+
+        requests_module = self._ensure_requests()
+
+        try:
+            response = requests_module.post(
+                endpoint,
+                json=payload,
+                timeout=self.settings.ollama_embed_timeout,
+            )
+        except requests_module.RequestException as exc:  # pragma: no cover - network errors
+            raise EmbeddingServiceError("Verbindung zu Ollama fehlgeschlagen.") from exc
+
+        if response.status_code >= 400:
+            raise EmbeddingServiceError(
+                f"Ollama antwortete mit Status {response.status_code}: {response.text}"
+            )
+
+        data = response.json()
+        vector = self._extract_vector(data)
+        return EmbeddingResponse(vector=vector, model=self.settings.ollama_embed_model, dimensions=len(vector))
+
+    def _generate_via_openai(self, text: str) -> EmbeddingResponse:
+        base_url = self.settings.openai_base_url.rstrip("/")
+        endpoint = f"{base_url}/embeddings"
+        payload = {"model": self.settings.openai_embed_model, "input": text}
+
+        requests_module = self._ensure_requests()
+        headers = {
+            "Authorization": f"Bearer {self.settings.openai_api_key}",
+            "Content-Type": "application/json",
+        }
+        if self.settings.openai_organization:
+            headers["OpenAI-Organization"] = self.settings.openai_organization
+
+        try:
+            response = requests_module.post(
+                endpoint,
+                json=payload,
+                headers=headers,
+                timeout=self.settings.openai_embed_timeout,
+            )
+        except requests_module.RequestException as exc:  # pragma: no cover - network errors
+            raise EmbeddingServiceError("Verbindung zur OpenAI Embedding-API fehlgeschlagen.") from exc
+
+        if response.status_code >= 400:
+            raise EmbeddingServiceError(
+                f"OpenAI antwortete mit Status {response.status_code}: {response.text}"
+            )
+
+        data = response.json()
+        try:
+            vector = list(data["data"][0]["embedding"])
+        except (KeyError, IndexError, TypeError) as exc:
+            raise EmbeddingServiceError("Ungültige Embedding-Antwort von OpenAI erhalten.") from exc
+
+        return EmbeddingResponse(
+            vector=vector,
+            model=self.settings.openai_embed_model,
+            dimensions=len(vector),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_requests(self):
+        if self._requests is None:
+            try:
+                import requests as requests_module  # type: ignore
+            except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+                raise EmbeddingServiceError("Das 'requests'-Paket wird für Embedding-Aufrufe benötigt.") from exc
+            self._requests = requests_module
+        return self._requests
+
+    @staticmethod
+    def _extract_vector(payload: dict) -> List[float]:
+        if "embedding" in payload:
+            return [float(x) for x in payload["embedding"]]
+
+        embeddings = payload.get("embeddings") or payload.get("data")
+        if embeddings:
+            first = embeddings[0]
+            if isinstance(first, dict):
+                vector = first.get("embedding")
+            else:
+                vector = first
+            if vector is not None:
+                return [float(x) for x in vector]
+
+        raise EmbeddingServiceError("Embedding-Vektor konnte nicht extrahiert werden.")
+
+    @staticmethod
+    def _fake_embedding(text: str) -> List[float]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        vector = []
+        # Use 16 bytes → 8 deterministic pseudo-random floats in range [-1, 1].
+        for index in range(0, 16, 2):
+            segment = digest[index : index + 2]
+            value = int.from_bytes(segment, "big", signed=False)
+            normalized = (value / 65535.0) * 2 - 1
+            vector.append(round(normalized, 6))
+        return vector
+
+
+def serialize_embedding(vector: Optional[Iterable[float]]) -> Optional[str]:
+    """Serialize an embedding vector into JSON."""
+
+    if vector is None:
+        return None
+    return json.dumps([float(x) for x in vector])
+
+
+def deserialize_embedding(payload: Optional[str]) -> Optional[List[float]]:
+    """Deserialize an embedding vector from JSON."""
+
+    if not payload:
+        return None
+    try:
+        loaded = json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise EmbeddingServiceError("Gespeicherter Embedding-Vektor ist kein gültiges JSON.") from exc
+
+    if not isinstance(loaded, list):
+        raise EmbeddingServiceError("Gespeicherter Embedding-Vektor hat ein ungültiges Format.")
+
+    return [float(x) for x in loaded]
+
+
+__all__ = [
+    "EmbeddingResponse",
+    "EmbeddingService",
+    "EmbeddingServiceError",
+    "deserialize_embedding",
+    "serialize_embedding",
+]

--- a/backend/tests/test_knowledge_service.py
+++ b/backend/tests/test_knowledge_service.py
@@ -1,0 +1,141 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.config import get_settings
+from backend.services.knowledge_service import KnowledgeBuilder
+from backend.services.rag_service import EmbeddingService, EmbeddingServiceError
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def stub_models(monkeypatch):
+    class FakeChunk:
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+            self.id = kwargs.get("id", f"chunk-{kwargs.get('chunk_index', 0)}")
+
+    fake_enum = SimpleNamespace(
+        TEXT=SimpleNamespace(value="text"),
+        TABLE=SimpleNamespace(value="table"),
+    )
+
+    stub_module = SimpleNamespace(KnowledgeChunk=FakeChunk, KnowledgeChunkTypeEnum=fake_enum)
+    monkeypatch.setitem(sys.modules, "backend.models", stub_module)
+    yield stub_module
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.added = []
+        self.flushed = False
+
+    def add(self, obj):  # pragma: no cover - simple container
+        self.added.append(obj)
+
+    def flush(self):  # pragma: no cover - simple container
+        self.flushed = True
+
+
+class FakeEmbeddingService:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def generate(self, text: str):
+        self.calls.append(text)
+        return SimpleNamespace(vector=[0.1, 0.2], model="fake", dimensions=2)
+
+
+@pytest.mark.parametrize(
+    "text,chunk_size,overlap,expected",
+    [
+        (
+            "abcdefghijklmnop",
+            6,
+            2,
+            ["abcdef", "efghij", "ijklmn", "mnop"],
+        ),
+        (
+            "kurz",
+            10,
+            2,
+            ["kurz"],
+        ),
+    ],
+)
+def test_split_text_respects_overlap(text, chunk_size, overlap, expected):
+    builder = KnowledgeBuilder(
+        db=DummySession(),
+        embedding_service=None,
+        max_chunk_chars=chunk_size,
+        chunk_overlap=overlap,
+    )
+
+    assert builder._split_text(text) == expected
+
+
+def test_split_text_rejects_invalid_overlap():
+    builder = KnowledgeBuilder(
+        db=DummySession(),
+        embedding_service=None,
+        max_chunk_chars=5,
+        chunk_overlap=5,
+    )
+
+    with pytest.raises(ValueError):
+        builder._split_text("abcdef")
+
+
+def test_persist_chunks_flushes_and_returns(stub_models):
+    session = DummySession()
+    builder = KnowledgeBuilder(db=session, embedding_service=FakeEmbeddingService())
+
+    dokument = SimpleNamespace(id="doc", projekt_id="proj")
+    chunk = builder._create_chunk(
+        dokument=dokument,
+        chunk_index=0,
+        chunk_type=stub_models.KnowledgeChunkTypeEnum.TEXT,
+        chunk_text="hello",
+        source_reference={"source": "test"},
+    )
+
+    persisted = builder.persist_chunks([chunk])
+
+    assert session.flushed is True
+    assert persisted[0].embedding_vector is not None
+
+
+def test_embedding_service_respects_test_mode(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    service = EmbeddingService.from_env()
+    assert service is not None
+
+    response = service.generate("Test eingabe")
+    assert response.model == "test/fake"
+    assert len(response.vector) == 8
+
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+
+def test_embedding_service_without_backend(monkeypatch):
+    monkeypatch.delenv("TEST_MODE", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert EmbeddingService.from_env() is None
+
+    service = EmbeddingService()
+
+    with pytest.raises(EmbeddingServiceError):
+        service.generate("text")


### PR DESCRIPTION
## Summary
- centralize runtime configuration in `backend/core` to expose unified access to embedding and vector settings
- enhance the embedding service with test-mode vectors, Ollama/OpenAI backends, and robust serialization helpers
- extend the knowledge builder to stream chunks to optional vector stores and cover the workflow with updated tests

## Testing
- pytest -q backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e133b62cd083249a74246e42f761b1